### PR TITLE
Clarify editing inside generated zip files

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,3 +30,8 @@ __Easily as never!__
 __The program was created for introductory purposes.__
 
 __Files in .pkg files may be copyrighted.__
+
+## Note
+__The work should be done "INSIDE" the zip file "DIRECTLY"!!__
+
+__Operations inside zip files doesn't work with File Explorer. Use 7zip or other softwares.__


### PR DESCRIPTION
This adds a README note clarifying that edits should be performed directly inside the generated zip archive, and that Windows File Explorer may not handle editing archive contents reliably.

This should help users avoid confusion when following the pkg-to-zip workflow. The PR is still mergeable against `master`.
